### PR TITLE
chore: Upgrade Nitro to 0.35.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - hermes-engine (250829098.0.7):
     - hermes-engine/Pre-built (= 250829098.0.7)
   - hermes-engine/Pre-built (250829098.0.7)
-  - NitroCookies (1.0.1):
+  - NitroCookies (1.0.4):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -27,7 +27,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - NitroModules (0.33.9):
+  - NitroModules (0.35.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2164,9 +2164,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
-  hermes-engine: c583d19e1b1b37ae22b2ca8542e9476c02347b0a
-  NitroCookies: 5bec4a8a01bfde0881236eb4f2a769b284f5a958
-  NitroModules: 97978583f36f88f7a348d5bf986d94bc4b340d0a
+  hermes-engine: fd12ee80b1bea1406a14a989d9f12683eadf07a0
+  NitroCookies: c6d053d654d5f77b71b6f56fc9b7e7ea046c57dc
+  NitroModules: ff0d24be334de628166b9ac63661c998c732de7d
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
   RCTRequired: 9854a51b0f65ccf43ea0b744df4d70fce339db32
   RCTSwiftUI: 96986e49a4fdc2c2103929dee2641e1b57edf33d
@@ -2175,7 +2175,7 @@ SPEC CHECKSUMS:
   React: 7ef36630d07638043a134a7dd2ec17e0be10fc3c
   React-callinvoker: af4e8fe1d60ab63dd8d74c2a68988064c2848954
   React-Core: c609976c034ba9556bef9850a571a71bd458d73f
-  React-Core-prebuilt: b52807d4aca6dcfb853efcfd8b914e5460e209f6
+  React-Core-prebuilt: 0d18e75395e979366510a72a06826ba8273f980a
   React-CoreModules: 0ea85f3b3f4b8cbfb3afacd2ed85458fb878517a
   React-cxxreact: 6752bab77c0599d6136e2b8b9b64b4a7d316d401
   React-debug: 38389b86e3570558ec73dd4cbc0cd2f2eec47a51
@@ -2238,9 +2238,9 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 6b7e8d8d974ed13fb66698d82c30c5e70c1f7d3a
   ReactCodegen: c5e5343f6691b0cd76913b9be5e89e5a83ff3315
   ReactCommon: 92b53b0bd7f7d86154dc9f512c1ea5dee717cc72
-  ReactNativeDependencies: c5c9aa28558f8243f3355f2c21ea90bc92b49aea
+  ReactNativeDependencies: ca8b893bcd359469b806a8f907d0819cf17e25ba
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 
 PODFILE CHECKSUM: 0ff2bbe9e5ff6b8979867c7ed05e77e5fe5a4fab
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "react": "19.2.3",
     "react-native": "0.84.0",
     "react-native-nitro-cookies": "*",
-    "react-native-nitro-modules": "0.33.9",
+    "react-native-nitro-modules": "0.35.0",
     "react-native-safe-area-context": "5.6.2",
     "react-native-webview": "13.16.0"
   },

--- a/package/android/src/main/cpp/cpp-adapter.cpp
+++ b/package/android/src/main/cpp/cpp-adapter.cpp
@@ -2,5 +2,7 @@
 #include "nitrocookiesOnLoad.hpp"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
-  return margelo::nitro::nitrocookies::initialize(vm);
+  return facebook::jni::initialize(vm, [=] {
+    margelo::nitro::nitrocookies::registerAllNatives();
+  });
 }

--- a/package/android/src/main/cpp/cpp-adapter.cpp
+++ b/package/android/src/main/cpp/cpp-adapter.cpp
@@ -1,4 +1,5 @@
 #include <jni.h>
+#include <fbjni/fbjni.h>
 #include "nitrocookiesOnLoad.hpp"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {

--- a/package/package.json
+++ b/package/package.json
@@ -77,17 +77,17 @@
     "@types/react": "19.2.14",
     "del-cli": "6.0.0",
     "jest": "30.2.0",
-    "nitrogen": "0.33.9",
+    "nitrogen": "0.35.0",
     "react": "19.2.3",
     "react-native": "0.84.0",
     "react-native-builder-bob": "0.40.18",
-    "react-native-nitro-modules": "0.33.9",
+    "react-native-nitro-modules": "0.35.0",
     "typescript": "5.9.3"
   },
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": "~0.33.9"
+    "react-native-nitro-modules": ">=0.35.0"
   },
   "prettier": {
     "quoteProps": "consistent",

--- a/package/package.json
+++ b/package/package.json
@@ -87,7 +87,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-modules": ">=0.35.0"
+    "react-native-nitro-modules": ">=0.35.0 <1.0.0"
   },
   "prettier": {
     "quoteProps": "consistent",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9806,18 +9806,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nitrogen@npm:0.33.9":
-  version: 0.33.9
-  resolution: "nitrogen@npm:0.33.9"
+"nitrogen@npm:0.35.0":
+  version: 0.35.0
+  resolution: "nitrogen@npm:0.35.0"
   dependencies:
     chalk: ^5.3.0
-    react-native-nitro-modules: ^0.33.9
+    react-native-nitro-modules: ^0.35.0
     ts-morph: ^27.0.0
     yargs: ^18.0.0
     zod: ^4.0.5
   bin:
     nitrogen: lib/index.js
-  checksum: 8406c4d85bdfa112740128707b646e56a764f958d17e65f46f14a0a4f0859499b77b29b044de9ba8566958263fc4b42e24a19f17033296e264ab6709088fc88a
+  checksum: d99d27ff6c5cacf1acaf11aa21ee58b401b1d185086b103a6cc26e92433505e4aef93b8a8281b21f872f219d8ad7a96412ac28c36894542a709eebb86e523fc3
   languageName: node
   linkType: hard
 
@@ -10766,7 +10766,7 @@ __metadata:
     react-native-builder-bob: 0.40.18
     react-native-harness: 1.0.0-alpha.25
     react-native-nitro-cookies: "*"
-    react-native-nitro-modules: 0.33.9
+    react-native-nitro-modules: 0.35.0
     react-native-safe-area-context: 5.6.2
     react-native-webview: 13.16.0
   languageName: unknown
@@ -10805,26 +10805,26 @@ __metadata:
     "@types/react": 19.2.14
     del-cli: 6.0.0
     jest: 30.2.0
-    nitrogen: 0.33.9
+    nitrogen: 0.35.0
     react: 19.2.3
     react-native: 0.84.0
     react-native-builder-bob: 0.40.18
-    react-native-nitro-modules: 0.33.9
+    react-native-nitro-modules: 0.35.0
     typescript: 5.9.3
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-nitro-modules: ~0.33.9
+    react-native-nitro-modules: ">=0.35.0"
   languageName: unknown
   linkType: soft
 
-"react-native-nitro-modules@npm:0.33.9, react-native-nitro-modules@npm:^0.33.9":
-  version: 0.33.9
-  resolution: "react-native-nitro-modules@npm:0.33.9"
+"react-native-nitro-modules@npm:0.35.0, react-native-nitro-modules@npm:^0.35.0":
+  version: 0.35.0
+  resolution: "react-native-nitro-modules@npm:0.35.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: b9f1ebe7621f600046e0c4701e33f3a038a256fdca84394011cdf431bbf7d142a28f2fa042df4f78b8c879740697ff53e0afca933316063eee0f24f27e920131
+  checksum: f006daa1aa58f1a0165a4d6fc087c8d190f2857a7acfd6b47080e5979f05beb20455ed3c66831d489df4eb57d2f430d1610094ed4d6ae3946e17d83362161aa6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10814,7 +10814,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-nitro-modules: ">=0.35.0"
+    react-native-nitro-modules: ">=0.35.0 <1.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Upgrades to [Nitro 0.35.0](https://github.com/mrousavy/nitro/releases/tag/v0.35.0), which contains a **BREAKING CHANGE** related to Kotlin HybridObjects (it fixes a critical memory leak, so it is advised everyone upgrades).

Steps I did (you can follow):
1. Upgrade react-native-nitro-modules and nitrogen to 0.35.0
2. Run `yarn install` & `pod install`
3. Re-generate specs using `yarn nitrogen`
4. Replaced the `cpp-adapter.cpp` call from `initialize(vm)` with `registerAllNatives()` - this allows you to register custom JNI natives in your libs, if needed.

Reference: [react-native-unistyles PR #1119](https://github.com/jpudysz/react-native-unistyles/pull/1119)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded react-native-nitro-modules to 0.35.0
  * Upgraded nitrogen development dependency to 0.35.0
  * Updated peer dependency constraints to reflect new minimum versions

* **Bug Fixes**
  * Improved native module initialization to ensure reliable registration during app startup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->