### PR TITLE
feat: add getCookieHeader and setMany

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,3 @@ logs/
 # Claude
 CLAUDE.md
 .claude/
-.specify/
-specs/
-.omc/
-openspec/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,6 @@ High-performance HTTP cookie management library for React Native using Nitro Mod
 | `eslint.config.mjs` | ESLint flat config for the monorepo |
 | `babel.config.js` | Babel configuration |
 | `lefthook.yml` | Git hooks (commitlint) |
-| `CLAUDE.md` | AI assistant instructions and project guidelines |
 | `CHANGELOG.md` | Release changelog (v1.0.0) |
 | `CONTRIBUTING.md` | Contribution guidelines |
 
@@ -23,9 +22,6 @@ High-performance HTTP cookie management library for React Native using Nitro Mod
 | Directory | Purpose |
 |-----------|---------|
 | `package/` | The npm package source: TypeScript API, iOS Swift, Android Kotlin, Nitrogen codegen (see `package/AGENTS.md`) |
-| `specs/` | Feature specifications and design documents (see `specs/AGENTS.md`) |
-| `openspec/` | OpenSpec change proposal system (see `openspec/AGENTS.md`) |
-| `.specify/` | SpecKit templates, scripts, and memory for feature planning (see `.specify/AGENTS.md`) |
 | `example/` | React Native example app for testing the library |
 
 ## For AI Agents

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ NitroCookies.setFromResponseSync("https://example.com", "session=abc; path=/");
 
 // Remove specific cookie
 NitroCookies.clearByNameSync("https://example.com", "session");
+
+// Set several cookies at once
+NitroCookies.setManySync("https://example.com", [
+  { name: "session", value: "abc123" },
+  { name: "theme", value: "dark" },
+]);
+
+// Get the ready-to-send Cookie request header (e.g. "session=abc123; theme=dark")
+const header = NitroCookies.getCookieHeaderSync("https://example.com");
 ```
 
 ### Asynchronous Methods
@@ -88,6 +97,8 @@ For operations requiring WebKit access (iOS), network requests, or callback-base
 | ------------------------------------ | -------------------------------------- |
 | `get(url, useWebKit?)`               | Get cookies for URL                    |
 | `set(url, cookie, useWebKit?)`       | Set a cookie                           |
+| `setMany(url, cookies, useWebKit?)`  | Set several cookies for a URL          |
+| `getCookieHeader(url, useWebKit?)`   | Get the `Cookie` request-header string |
 | `clearAll(useWebKit?)`               | Clear all cookies                      |
 | `clearByName(url, name, useWebKit?)` | Remove specific cookie                 |
 | `setFromResponse(url, header)`       | Parse Set-Cookie header                |
@@ -119,6 +130,25 @@ interface Cookie {
   expires?: string; // ISO 8601 format
 }
 ```
+
+## Attaching cookies to a manual request
+
+`getCookieHeader` returns the exact value of the HTTP `Cookie` request header for
+a URL, so you can forward stored cookies on a `fetch` or `XMLHttpRequest` you build
+yourself:
+
+```typescript
+const header = await NitroCookies.getCookieHeader("https://api.example.com");
+
+await fetch("https://api.example.com/profile", {
+  headers: header ? { Cookie: header } : {},
+});
+```
+
+On iOS the header is built with `HTTPCookie.requestHeaderFields(with:)`, so name/value
+serialization follows the platform's RFC 6265 rules; on Android it maps directly to
+`CookieManager.getCookie(url)`. The synchronous `getCookieHeaderSync` is available for
+hot paths.
 
 ## WebView Integration (iOS)
 

--- a/package/android/src/main/java/com/margelo/nitro/nitrocookies/NitroCookies.kt
+++ b/package/android/src/main/java/com/margelo/nitro/nitrocookies/NitroCookies.kt
@@ -268,6 +268,39 @@ class NitroCookies : HybridNitroCookiesSpec() {
     return false
   }
 
+  /**
+   * Get the Cookie request-header string synchronously for a URL.
+   *
+   * CookieManager.getCookie() already returns the value in the format of the
+   * 'Cookie' HTTP request header ("name1=value1; name2=value2"), so this is a
+   * near pass-through.
+   */
+  override fun getCookieHeaderSync(url: String): String {
+    validateURL(url)
+    return CookieManager.getInstance().getCookie(url) ?: ""
+  }
+
+  /** Set multiple cookies synchronously */
+  override fun setManySync(url: String, cookies: Array<Cookie>): Boolean {
+    val urlObj = validateURL(url)
+
+    // Validate every cookie up front so a bad cookie doesn't leave a partial write
+    for (cookie in cookies) {
+      validateDomain(cookie, urlObj)
+    }
+
+    val cookieManager = CookieManager.getInstance()
+    cookieManager.setAcceptCookie(true)
+
+    for (cookie in cookies) {
+      val cookieWithDefaults =
+        cookie.copy(path = cookie.path ?: "/", domain = cookie.domain ?: urlObj.host)
+      cookieManager.setCookie(url, toRFC6265String(cookieWithDefaults))
+    }
+
+    return true
+  }
+
   // MARK: - Asynchronous Cookie Operations
 
   /** Set a single cookie */
@@ -287,6 +320,42 @@ class NitroCookies : HybridNitroCookiesSpec() {
       cookieManager.setCookie(url, setCookieString)
 
       true
+    }
+  }
+
+  /** Set multiple cookies for a URL */
+  override fun setMany(url: String, cookies: Array<Cookie>, useWebKit: Boolean?): Promise<Boolean> {
+    return Promise.async {
+      val urlObj = validateURL(url)
+
+      // Validate every cookie up front so a bad cookie doesn't leave a partial write
+      for (cookie in cookies) {
+        validateDomain(cookie, urlObj)
+      }
+
+      val cookieManager = CookieManager.getInstance()
+      cookieManager.setAcceptCookie(true)
+
+      for (cookie in cookies) {
+        val cookieWithDefaults =
+          cookie.copy(path = cookie.path ?: "/", domain = cookie.domain ?: urlObj.host)
+        cookieManager.setCookie(url, toRFC6265String(cookieWithDefaults))
+      }
+
+      true
+    }
+  }
+
+  /**
+   * Get the Cookie request-header string for a URL.
+   *
+   * CookieManager.getCookie() already returns the value in the format of the
+   * 'Cookie' HTTP request header, so this is a near pass-through.
+   */
+  override fun getCookieHeader(url: String, useWebKit: Boolean?): Promise<String> {
+    return Promise.async {
+      validateURL(url)
+      CookieManager.getInstance().getCookie(url) ?: ""
     }
   }
 

--- a/package/ios/NitroCookies.swift
+++ b/package/ios/NitroCookies.swift
@@ -291,6 +291,40 @@ public class HybridNitroCookies: HybridNitroCookiesSpec {
         }
     }
 
+    /**
+     * Get the Cookie request-header string synchronously for a URL
+     * Uses NSHTTPCookieStorage only (WebKit not supported for sync operations)
+     */
+    public func getCookieHeaderSync(url urlString: String) throws -> String {
+        let url = try validateURL(urlString)
+        let allCookies = HTTPCookieStorage.shared.cookies ?? []
+        let matched = allCookies.filter { cookie in
+            self.isMatchingDomain(cookieDomain: cookie.domain,
+                                 urlHost: url.host ?? "")
+        }
+        return HTTPCookie.requestHeaderFields(with: matched)["Cookie"] ?? ""
+    }
+
+    /**
+     * Set multiple cookies synchronously
+     * Uses NSHTTPCookieStorage only (WebKit not supported for sync operations)
+     */
+    public func setManySync(url urlString: String, cookies: [Cookie]) throws -> Bool {
+        let url = try validateURL(urlString)
+
+        // Validate every cookie up front so a bad cookie doesn't leave a partial write
+        for cookie in cookies {
+            try validateDomain(cookie: cookie, url: url)
+        }
+
+        let storage = HTTPCookieStorage.shared
+        for cookie in cookies {
+            let httpCookie = try makeHTTPCookie(from: cookie, url: url)
+            storage.setCookie(httpCookie)
+        }
+        return true
+    }
+
     // MARK: - Asynchronous Cookie Operations
 
     /**
@@ -320,6 +354,73 @@ public class HybridNitroCookies: HybridNitroCookiesSpec {
                 HTTPCookieStorage.shared.setCookie(httpCookie)
                 return true
             }
+        }
+    }
+
+    /**
+     * Set multiple cookies for a URL
+     */
+    public func setMany(url urlString: String, cookies: [Cookie], useWebKit: Bool?) throws -> Promise<Bool> {
+        return Promise.async {
+            let url = try self.validateURL(urlString)
+
+            // Validate every cookie up front so a bad cookie doesn't leave a partial write
+            for cookie in cookies {
+                try self.validateDomain(cookie: cookie, url: url)
+            }
+
+            let httpCookies = try cookies.map { try self.makeHTTPCookie(from: $0, url: url) }
+
+            if useWebKit == true {
+                if #available(iOS 11.0, *) {
+                    for httpCookie in httpCookies {
+                        await self.withWebKitStoreVoid { store, done in
+                            store.setCookie(httpCookie) { done() }
+                        }
+                    }
+                    return true
+                } else {
+                    throw NSError(domain: "WEBKIT_UNAVAILABLE", code: 3,
+                                 userInfo: [NSLocalizedDescriptionKey:
+                                    "WebKit requires iOS 11 or higher"])
+                }
+            } else {
+                let storage = HTTPCookieStorage.shared
+                for httpCookie in httpCookies {
+                    storage.setCookie(httpCookie)
+                }
+                return true
+            }
+        }
+    }
+
+    /**
+     * Get the Cookie request-header string for a URL
+     */
+    public func getCookieHeader(url urlString: String, useWebKit: Bool?) throws -> Promise<String> {
+        return Promise.async {
+            let url = try self.validateURL(urlString)
+
+            let httpCookies: [HTTPCookie]
+            if useWebKit == true {
+                if #available(iOS 11.0, *) {
+                    httpCookies = await self.withWebKitStore { store, done in
+                        store.getAllCookies { cookies in done(cookies) }
+                    }
+                } else {
+                    throw NSError(domain: "WEBKIT_UNAVAILABLE", code: 3,
+                                 userInfo: [NSLocalizedDescriptionKey:
+                                    "WebKit requires iOS 11 or higher"])
+                }
+            } else {
+                httpCookies = HTTPCookieStorage.shared.cookies ?? []
+            }
+
+            let matched = httpCookies.filter { cookie in
+                self.isMatchingDomain(cookieDomain: cookie.domain,
+                                     urlHost: url.host ?? "")
+            }
+            return HTTPCookie.requestHeaderFields(with: matched)["Cookie"] ?? ""
         }
     }
 

--- a/package/src/NitroCookies.nitro.ts
+++ b/package/src/NitroCookies.nitro.ts
@@ -75,6 +75,33 @@ export interface NitroCookies extends HybridObject<{
    */
   clearByNameSync(url: string, name: string): boolean;
 
+  /**
+   * Get the `Cookie` request-header string for a URL synchronously
+   *
+   * Returns the value you would put in an HTTP `Cookie` request header
+   * (e.g. "name1=value1; name2=value2"), built from every cookie that
+   * matches the URL. Use this to attach cookies to a manual `fetch`/
+   * `XMLHttpRequest`. Uses NSHTTPCookieStorage (iOS) or CookieManager (Android).
+   *
+   * @param url - The URL to match cookies against (must include protocol)
+   * @returns The Cookie header string, or "" when no cookies match
+   * @throws Error if URL is invalid
+   */
+  getCookieHeaderSync(url: string): string;
+
+  /**
+   * Set multiple cookies for a URL synchronously
+   *
+   * Applies the same domain validation as `setSync` to every cookie.
+   * Uses NSHTTPCookieStorage (iOS) or CookieManager (Android).
+   *
+   * @param url - The URL for which to set the cookies (must include protocol)
+   * @param cookies - The cookie objects to store
+   * @returns true on success
+   * @throws Error if URL is invalid or any cookie's domain mismatches
+   */
+  setManySync(url: string, cookies: Cookie[]): boolean;
+
   // ========================================
   // ASYNCHRONOUS METHODS
   // ========================================
@@ -88,6 +115,35 @@ export interface NitroCookies extends HybridObject<{
    * @returns Promise that resolves to true on success
    */
   set(url: string, cookie: Cookie, useWebKit?: boolean): Promise<boolean>;
+
+  /**
+   * Set multiple cookies for a URL
+   *
+   * Applies the same domain validation as `set` to every cookie.
+   *
+   * @param url - The URL for which to set the cookies (must include protocol)
+   * @param cookies - The cookie objects to store
+   * @param useWebKit - (iOS only) If true, use WKHTTPCookieStore instead of NSHTTPCookieStorage (requires iOS 11+)
+   * @returns Promise that resolves to true on success
+   */
+  setMany(
+    url: string,
+    cookies: Cookie[],
+    useWebKit?: boolean
+  ): Promise<boolean>;
+
+  /**
+   * Get the `Cookie` request-header string for a URL
+   *
+   * Returns the value you would put in an HTTP `Cookie` request header
+   * (e.g. "name1=value1; name2=value2"), built from every cookie that
+   * matches the URL.
+   *
+   * @param url - The URL to match cookies against (must include protocol)
+   * @param useWebKit - (iOS only) If true, read from WKHTTPCookieStore instead of NSHTTPCookieStorage
+   * @returns Promise that resolves to the Cookie header string, or "" when no cookies match
+   */
+  getCookieHeader(url: string, useWebKit?: boolean): Promise<string>;
 
   /**
    * Get all cookies matching a specific URL's domain

--- a/package/src/__tests__/index.test.tsx
+++ b/package/src/__tests__/index.test.tsx
@@ -1,5 +1,96 @@
-describe('react-native-nitro-cookies', () => {
-  it('should pass placeholder test', () => {
-    expect(true).toBe(true);
+import type { Cookie } from '../types';
+
+// Mock the native HybridObject so we can assert the JS wrapper layer forwards
+// arguments correctly (defaults, pass-through return values) without a JSI runtime.
+// The mock object is created inside the (hoisted) factory and exposed via a getter
+// to dodge jest's "Cannot access before initialization" hoisting rule.
+jest.mock('react-native-nitro-modules', () => {
+  const hybrid = {
+    getSync: jest.fn(),
+    setSync: jest.fn(),
+    setFromResponseSync: jest.fn(),
+    clearByNameSync: jest.fn(),
+    getCookieHeaderSync: jest.fn(),
+    setManySync: jest.fn(),
+    set: jest.fn(),
+    setMany: jest.fn(),
+    getCookieHeader: jest.fn(),
+    get: jest.fn(),
+    clearAll: jest.fn(),
+    setFromResponse: jest.fn(),
+    getFromResponse: jest.fn(),
+    getAll: jest.fn(),
+    clearByName: jest.fn(),
+    flush: jest.fn(),
+    removeSessionCookies: jest.fn(),
+  };
+  return {
+    NitroModules: { createHybridObject: jest.fn(() => hybrid) },
+    __mockHybrid: hybrid,
+  };
+});
+
+import { NitroCookies } from '../index';
+
+const { __mockHybrid: mockHybrid } = require('react-native-nitro-modules');
+
+const URL = 'https://example.com';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getCookieHeaderSync', () => {
+  it('returns the header string from the native layer', () => {
+    mockHybrid.getCookieHeaderSync.mockReturnValue('a=1; b=2');
+    expect(NitroCookies.getCookieHeaderSync(URL)).toBe('a=1; b=2');
+    expect(mockHybrid.getCookieHeaderSync).toHaveBeenCalledWith(URL);
+  });
+
+  it('passes through an empty string when no cookies match', () => {
+    mockHybrid.getCookieHeaderSync.mockReturnValue('');
+    expect(NitroCookies.getCookieHeaderSync(URL)).toBe('');
+  });
+});
+
+describe('getCookieHeader', () => {
+  it('resolves the header string and defaults useWebKit to false', async () => {
+    mockHybrid.getCookieHeader.mockResolvedValue('a=1; b=2');
+    await expect(NitroCookies.getCookieHeader(URL)).resolves.toBe('a=1; b=2');
+    expect(mockHybrid.getCookieHeader).toHaveBeenCalledWith(URL, false);
+  });
+
+  it('forwards an explicit useWebKit flag', async () => {
+    mockHybrid.getCookieHeader.mockResolvedValue('');
+    await NitroCookies.getCookieHeader(URL, true);
+    expect(mockHybrid.getCookieHeader).toHaveBeenCalledWith(URL, true);
+  });
+});
+
+describe('setManySync', () => {
+  it('forwards the cookie array and returns the native result', () => {
+    const cookies: Cookie[] = [
+      { name: 'session', value: 'abc123' },
+      { name: 'theme', value: 'dark' },
+    ];
+    mockHybrid.setManySync.mockReturnValue(true);
+    expect(NitroCookies.setManySync(URL, cookies)).toBe(true);
+    expect(mockHybrid.setManySync).toHaveBeenCalledWith(URL, cookies);
+  });
+});
+
+describe('setMany', () => {
+  it('resolves true and defaults useWebKit to false', async () => {
+    const cookies: Cookie[] = [{ name: 'session', value: 'abc123' }];
+    mockHybrid.setMany.mockResolvedValue(true);
+    await expect(NitroCookies.setMany(URL, cookies)).resolves.toBe(true);
+    expect(mockHybrid.setMany).toHaveBeenCalledWith(URL, cookies, false);
+  });
+
+  it('forwards an explicit useWebKit flag', async () => {
+    const cookies: Cookie[] = [{ name: 'session', value: 'abc123' }];
+    mockHybrid.setMany.mockResolvedValue(true);
+    await NitroCookies.setMany(URL, cookies, true);
+    expect(mockHybrid.setMany).toHaveBeenCalledWith(URL, cookies, true);
   });
 });

--- a/package/src/index.tsx
+++ b/package/src/index.tsx
@@ -123,6 +123,53 @@ export const NitroCookies = {
     return NitroCookiesHybridObject.clearByNameSync(url, name);
   },
 
+  /**
+   * Get the `Cookie` request-header string for a URL synchronously.
+   *
+   * Returns the value you would put in an HTTP `Cookie` request header
+   * (e.g. `"name1=value1; name2=value2"`), built from every cookie that
+   * matches the URL. Handy for attaching cookies to a manual `fetch` or
+   * `XMLHttpRequest`. Returns an empty string when no cookies match.
+   *
+   * @param url - The URL to match cookies against (must include protocol)
+   * @returns The Cookie header string, or "" when no cookies match
+   * @throws {Error} INVALID_URL - URL is malformed or missing protocol
+   *
+   * @example
+   * ```typescript
+   * const header = NitroCookies.getCookieHeaderSync('https://example.com');
+   * await fetch('https://example.com/api', { headers: { Cookie: header } });
+   * ```
+   */
+  getCookieHeaderSync(url: string): string {
+    return NitroCookiesHybridObject.getCookieHeaderSync(url);
+  },
+
+  /**
+   * Set multiple cookies for a URL synchronously.
+   *
+   * Applies the same domain validation as `setSync` to every cookie. If any
+   * cookie's domain doesn't match the URL host, the whole call throws and no
+   * cookies are written.
+   *
+   * @param url - The URL for which to set the cookies (must include protocol)
+   * @param cookies - The cookie objects to store
+   * @returns true on success
+   * @throws {Error} INVALID_URL - URL is malformed or missing protocol
+   * @throws {Error} DOMAIN_MISMATCH - A cookie's domain doesn't match URL host
+   *
+   * @example
+   * ```typescript
+   * NitroCookies.setManySync('https://example.com', [
+   *   { name: 'session', value: 'abc123' },
+   *   { name: 'theme', value: 'dark' },
+   * ]);
+   * ```
+   */
+  setManySync(url: string, cookies: Cookie[]): boolean {
+    return NitroCookiesHybridObject.setManySync(url, cookies);
+  },
+
   // ========================================
   // ASYNCHRONOUS METHODS
   // ========================================
@@ -166,6 +213,63 @@ export const NitroCookies = {
     useWebKit?: boolean
   ): Promise<boolean> {
     return NitroCookiesHybridObject.set(url, cookie, useWebKit ?? false);
+  },
+
+  /**
+   * Set multiple cookies for a URL.
+   *
+   * Applies the same domain validation as `set` to every cookie. If any
+   * cookie's domain doesn't match the URL host, the whole call rejects and no
+   * cookies are written.
+   *
+   * @param url - The URL for which to set the cookies. Must include protocol.
+   * @param cookies - The cookie objects to store
+   * @param useWebKit - (iOS only) If true, use WKHTTPCookieStore instead of NSHTTPCookieStorage. Requires iOS 11+.
+   *
+   * @returns Promise that resolves to true on success
+   *
+   * @throws {Error} INVALID_URL - URL is malformed or missing protocol
+   * @throws {Error} DOMAIN_MISMATCH - A cookie's domain doesn't match URL host
+   * @throws {Error} WEBKIT_UNAVAILABLE - useWebKit=true on iOS < 11
+   *
+   * @example
+   * ```typescript
+   * await NitroCookies.setMany('https://example.com', [
+   *   { name: 'session', value: 'abc123', secure: true },
+   *   { name: 'theme', value: 'dark' },
+   * ]);
+   * ```
+   */
+  async setMany(
+    url: string,
+    cookies: Cookie[],
+    useWebKit?: boolean
+  ): Promise<boolean> {
+    return NitroCookiesHybridObject.setMany(url, cookies, useWebKit ?? false);
+  },
+
+  /**
+   * Get the `Cookie` request-header string for a URL.
+   *
+   * Returns the value you would put in an HTTP `Cookie` request header
+   * (e.g. `"name1=value1; name2=value2"`), built from every cookie that
+   * matches the URL. Returns an empty string when no cookies match.
+   *
+   * @param url - The URL to match cookies against. Must include protocol.
+   * @param useWebKit - (iOS only) If true, read from WKHTTPCookieStore instead of NSHTTPCookieStorage
+   *
+   * @returns Promise that resolves to the Cookie header string, or "" when no cookies match
+   *
+   * @throws {Error} INVALID_URL - URL is malformed or missing protocol
+   *
+   * @example
+   * ```typescript
+   * const header = await NitroCookies.getCookieHeader('https://example.com');
+   * await fetch('https://example.com/api', { headers: { Cookie: header } });
+   * ```
+   */
+  async getCookieHeader(url: string, useWebKit?: boolean): Promise<string> {
+    return NitroCookiesHybridObject.getCookieHeader(url, useWebKit ?? false);
   },
 
   /**


### PR DESCRIPTION
Adds two cross-platform cookie methods, plus sync variants, verified against first-party platform APIs (iOS `NSHTTPCookieStorage`/`HTTPCookie`, Android `CookieManager`).

## What

- `getCookieHeader(url, useWebKit?)` / `getCookieHeaderSync(url)`: returns the `Cookie` request-header string for a URL (e.g. `"a=1; b=2"`), so callers can attach stored cookies to a manual `fetch`/`XMLHttpRequest`. Returns an empty string when nothing matches.
  - iOS builds it with `HTTPCookie.requestHeaderFields(with:)` for correct RFC 6265 serialization. Android maps to `CookieManager.getCookie(url)`, which already returns that exact format.
- `setMany(url, cookies, useWebKit?)` / `setManySync(url, cookies)`: sets an array of cookies for a URL. Every cookie is domain-validated up front, so a bad cookie rejects the whole call without a partial write.

Both features are symmetric across iOS and Android (no platform-only behavior).

## Why

`get()` returns a dictionary keyed by name, so building a `Cookie` header by hand risks getting the serialization wrong. Setting N cookies previously meant N separate calls. These two methods close those gaps with one consistent validation and return contract.

## Notes

- Generated Nitrogen bindings are git-ignored and regenerated locally, so this PR only touches the source interface, native implementations, TS wrapper, tests, and docs.
- A separate commit removes leftover OpenSpec/SpecKit tooling references that were checked into `AGENTS.md` and `.gitignore`.

## Verification

- `yarn typecheck`: clean
- `yarn test`: 7 wrapper tests pass (argument forwarding, `useWebKit` default, pass-through)
- `yarn lint`: clean
- `yarn nitrogen`: regenerates without errors, and the four new methods appear in the generated C++ spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch cookie operations: `setMany()` and `setManySync()` for efficiently setting multiple cookies at once
  * Added cookie header retrieval: `getCookieHeader()` and `getCookieHeaderSync()` to obtain formatted `Cookie` request headers for manual request construction

* **Documentation**
  * Updated API documentation to cover new batch cookie operations and cookie header retrieval methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->