### PR TITLE
docs: add prior-art credit for @react-native-cookies/cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Drop-in replacement - just change the import:
 // All existing code works unchanged!
 ```
 
+## Prior Art
+
+This package is a from-scratch Nitro Modules implementation, not a fork, but its public API and behavior are modeled on [`@react-native-cookies/cookies`](https://github.com/react-native-cookies/cookies). Big thanks to its maintainers and contributors for the original implementation and long-term work on the project.
+
 ## Acknowledgement
 
 - [This Week In React](https://thisweekinreact.com/)


### PR DESCRIPTION
## Summary
- Adds a "Prior Art" section to the README crediting [`@react-native-cookies/cookies`](https://github.com/react-native-cookies/cookies), since this library's public API and behavior are modeled on it (see the existing "Migration from @react-native-cookies/cookies" section) — worded to make clear this is a from-scratch Nitro Modules implementation, not a fork
- Initial draft used "Upstream," which was inaccurate since nothing was forked; reworded after reconsidering the relationship

## Test plan
- [x] Rendered the README section locally to confirm formatting/links are correct